### PR TITLE
Improve product add-to-cart UX

### DIFF
--- a/components/site/CartDrawer.tsx
+++ b/components/site/CartDrawer.tsx
@@ -148,6 +148,15 @@ export function CartDrawer({ trigger }: CartDrawerProps) {
   }, []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleOpen = () => setOpen(true);
+    window.addEventListener('wura:cart-open', handleOpen);
+    return () => {
+      window.removeEventListener('wura:cart-open', handleOpen);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!open) return;
     if (typeof window === 'undefined') return;
 


### PR DESCRIPTION
## Summary
- reworked product card call-to-action with inline selection guidance, loading/added states, and selection summary chips
- open the cart drawer automatically after adding an item and surface clearer status messaging for shoppers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e0fbe6df74833386cb5909f5a8d862